### PR TITLE
feat: create skeleton of a user profile page

### DIFF
--- a/src/features/user/Profile.tsx
+++ b/src/features/user/Profile.tsx
@@ -1,8 +1,59 @@
-import React from 'react'
+import { useAppSelector, useNavigateToPath } from '../../app/hooks';
+// user slice imports
+import { selectUser, getAccountDays } from './userSlice';
+// components
+import Button from '../../components/Button';
+
+type ButtonOption = {
+  [key: string]: React.MouseEventHandler<HTMLButtonElement>;
+}
 
 const Profile = () => {
+  const user = useAppSelector(selectUser);
+  const navigate = useNavigateToPath();
+  const days = getAccountDays(user.dateCreated);
+
+  const handleLogout = () => {
+    console.log('log out');
+  }
+
+  const handleChangePassword = () => {
+    console.log('change password');
+  }
+
+  const handleDeleteAccount = () => {
+    console.log('delete account');
+  }
+
+  const buttonBox: ButtonOption = {
+    "Log out": handleLogout,
+    "Change password": handleChangePassword,
+    "Delete account": handleDeleteAccount,
+  }
+
   return (
-    <div>Profile</div>
+    <div className='profile-page'>
+
+      {/* main of the profile */}
+      <main>
+        <h3>Hello!</h3>
+        <div>Days since account created: {days}</div>
+
+      {/* profile buttons */}
+        <div className='button-box'>
+         {Object.entries(buttonBox).map(([buttonText, handlerFunc]) => (
+          <Button key={buttonText} text={buttonText} onClick={handlerFunc} />
+         ))}
+        </div>
+      </main>
+
+      {/* sidebar */}
+      <div className='sidebar'>
+        <Button text="All plants" onClick={() => navigate('/all-plants')} />
+        <Button text="Add new plant" onClick={() => navigate('/add-new-plant')} />
+      </div>
+
+    </div>
   )
 }
 


### PR DESCRIPTION
## Description

This pull request implements the user profile page as outlined in the related issue. The page includes functionality for logging out, changing the password, and deleting the account. It also provides navigation buttons to redirect the user to the "All plants" display and the "Add new plant" page. This approach enhances user experience by allowing easy management of the user account.

## Related Issue

closes #8 

## Acceptance Criteria

- The profile page should display the correct account information and days since account creation.
- The "Log out," "Change password," and "Delete account" buttons should call their respective functions.
- The sidebar should have navigation buttons for "All plants" and "Add new plant."

## Type of Changes

- enhancement

## Testing Steps / QA Criteria

1. Navigate to the profile page after logging in.
2. Verify that the greeting message and the number of days since account creation are displayed correctly.
3. Click on the "Log out" button to ensure the logout function works as expected.
4. Click on the "Change password" and "Delete account" buttons to confirm that they trigger the appropriate console logs.
5. Use the sidebar buttons to navigate to the "All plants" and "Add new plant" pages, checking that the navigation works correctly.
